### PR TITLE
Create prototype using the axum framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,14 @@ publish = false
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[example]]
+name = "hello-world"
+
 [dependencies]
+axum = "0.5.6"
+hyper = "0.14.18"
+thiserror = "1.0.31"
+
+[dev-dependencies]
+reqwest = "0.11.10"
+tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,0 +1,7 @@
+use octox::{Error, Octox};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let octox = Octox::new();
+    octox.serve().await
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("failed to initialize the web framework")]
+    Axum(#[from] hyper::Error),
+    #[error("failed to initialize resources")]
+    Io(#[from] std::io::Error),
+    #[error("an unknown error occurred")]
+    Unknown,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,117 @@
+use std::fmt::{Display, Formatter};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+
+use axum::routing::get;
+use axum::{Router, Server};
+
+pub use self::error::Error;
+
+mod error;
+
+#[derive(Debug)]
+pub struct Octox {
+    address: SocketAddr,
+    tcp_listener: Option<TcpListener>,
+}
+
+impl Octox {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn address(mut self, address: SocketAddr) -> Result<Self, Error> {
+        self.address = address;
+        self.tcp_listener = None;
+        Ok(self)
+    }
+
+    pub fn listener(mut self, listener: TcpListener) -> Result<Self, Error> {
+        self.address = listener.local_addr()?;
+        self.tcp_listener = Some(listener);
+        Ok(self)
+    }
+
+    pub async fn serve(self) -> Result<(), Error> {
+        let app = Router::new().route("/", get(|| async { "Hello, World!" }));
+
+        let listener = match self.tcp_listener {
+            Some(listener) => listener,
+            None => TcpListener::bind(self.address)?,
+        };
+
+        Server::from_tcp(listener)?
+            .serve(app.into_make_service())
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl Display for Octox {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Octox {{}}")
+    }
+}
+
+impl Default for Octox {
+    fn default() -> Self {
+        Self {
+            address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 3000),
+            tcp_listener: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::net::{SocketAddr, TcpListener};
+
+    use super::{Error, Octox};
+
     #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+    fn new_returns_default_instance() {
+        let octox = Octox::new();
+
+        assert_eq!("127.0.0.1:3000", octox.address.to_string());
+    }
+
+    #[test]
+    fn address_sets_address() -> Result<(), Error> {
+        let octox = Octox::new();
+
+        let octox = octox.address("127.0.0.1:8000".parse::<SocketAddr>().unwrap())?;
+
+        assert_eq!("127.0.0.1:8000", octox.address.to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn address_resets_listener() -> Result<(), Error> {
+        let octox = Octox::new();
+
+        let octox = octox.listener(TcpListener::bind(
+            "0.0.0.0:0".parse::<SocketAddr>().unwrap(),
+        )?)?;
+        let octox = octox.address("127.0.0.1:8000".parse::<SocketAddr>().unwrap())?;
+
+        assert_eq!("127.0.0.1:8000", octox.address.to_string());
+        assert!(octox.tcp_listener.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn listener_resets_address() -> Result<(), Error> {
+        let octox = Octox::new();
+
+        let tcp_listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+        let address = tcp_listener.local_addr()?;
+
+        let octox = octox.listener(tcp_listener)?;
+
+        assert_eq!(address, octox.address);
+
+        Ok(())
     }
 }

--- a/tests/root.rs
+++ b/tests/root.rs
@@ -1,0 +1,51 @@
+use std::net::{SocketAddr, TcpListener};
+
+use reqwest::Client;
+
+use octox::{Error, Octox};
+
+#[tokio::test]
+async fn root_returns_ok() -> Result<(), Error> {
+    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+    let addr = listener.local_addr()?;
+
+    let octox = Octox::new().listener(listener)?;
+
+    tokio::spawn(async move {
+        octox.serve().await.unwrap();
+    });
+
+    let response = Client::new()
+        .get(format!("http://{}", addr))
+        .send()
+        .await
+        .expect("failed to execute request");
+
+    assert!(response.status().is_success());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn root_prints_hello_world() -> Result<(), Error> {
+    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+    let addr = listener.local_addr()?;
+
+    let octox = Octox::new().listener(listener)?;
+
+    tokio::spawn(async move {
+        octox.serve().await.unwrap();
+    });
+
+    let response = Client::new()
+        .get(format!("http://{}", addr))
+        .send()
+        .await
+        .expect("failed to execute request");
+
+    let body = response.text().await.unwrap();
+
+    assert_eq!("Hello, World!", body);
+
+    Ok(())
+}


### PR DESCRIPTION
A very simple prototype for octox has been created using the axum web framework. The prototype serves static content on a static endpoint, but already allows the configuration of the server interface through a builder pattern.