### PR TITLE
Enable configuration of GitHub host

### DIFF
--- a/tests/root.rs
+++ b/tests/root.rs
@@ -11,7 +11,7 @@ async fn root_returns_ok() -> Result<(), Error> {
     let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
     let addr = listener.local_addr()?;
 
-    let octox = Octox::new().listener(listener)?;
+    let octox = Octox::new().tcp_listener(listener)?;
 
     tokio::spawn(async move {
         octox.serve().await.unwrap();
@@ -35,7 +35,7 @@ async fn root_prints_hello_world() -> Result<(), Error> {
     let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
     let addr = listener.local_addr()?;
 
-    let octox = Octox::new().listener(listener)?;
+    let octox = Octox::new().tcp_listener(listener)?;
 
     tokio::spawn(async move {
         octox.serve().await.unwrap();


### PR DESCRIPTION
GitHub provides self-hosted environments via their GitHub Enterprise offering. To support these, a new configuration option that contains the URL of the server has been added.