### PR TITLE
Deserialize webhook payload

### DIFF
--- a/.github/workflows/push-rust.yml
+++ b/.github/workflows/push-rust.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v1.4.0
 
+      - name: Cache credentials for private crates
+        run: |
+          git config --global credential.helper store
+          git clone https://jdno:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/devxbots/github-parts
+
       - name: Run Clippy
         uses: actions-rs/cargo@v1
         with:
@@ -94,6 +99,11 @@ jobs:
             echo "Run tests without coverage"
             echo "::set-output name=enable::false"
           fi
+
+      - name: Cache credentials for private crates
+        run: |
+          git config --global credential.helper store
+          git clone https://jdno:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/devxbots/github-parts
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ publish = false
 name = "hello-world"
 
 [dependencies]
+github-parts = { git = "https://github.com/devxbots/github-parts", tag = "v0.1.0" }
+
 axum = "0.5.6"
 chrono = "0.4.19"
 hex = "0.4.3"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,6 +16,7 @@ pub enum AuthError {
     WrongSignatureFormat,
     FailedDecodingSignature,
     InvalidSignature,
+    UnexpectedPayload,
 }
 
 impl IntoResponse for AuthError {
@@ -40,6 +41,10 @@ impl IntoResponse for AuthError {
             AuthError::InvalidSignature => (
                 StatusCode::UNAUTHORIZED,
                 "X-Hub-Signature-256 header is invalid".into(),
+            ),
+            AuthError::UnexpectedPayload => (
+                StatusCode::BAD_REQUEST,
+                "failed to deserialize the body based of the X-GitHub-Event header".into(),
             ),
         };
 

--- a/src/routes/webhook.rs
+++ b/src/routes/webhook.rs
@@ -1,6 +1,7 @@
 use axum::body::Bytes;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Extension;
+use github_parts::event::Event;
 
 use crate::auth::{verify_signature, AuthError};
 use crate::WebhookSecret;
@@ -10,20 +11,34 @@ pub async fn webhook(
     body: Bytes,
     Extension(webhook_secret): Extension<WebhookSecret>,
 ) -> Result<StatusCode, AuthError> {
-    let signature = get_signature(headers)?;
+    let signature = get_signature(&headers)?;
     verify_signature(&body, &signature, &webhook_secret)?;
+
+    let event_type = get_event(&headers)?;
+    let _event = deserialize_event(&event_type, &body)?;
 
     Ok(StatusCode::OK)
 }
 
-fn get_signature(headers: HeaderMap) -> Result<String, AuthError> {
+fn get_signature(headers: &HeaderMap) -> Result<String, AuthError> {
     get_header(headers, "X-Hub-Signature-256")
 }
 
-fn get_header(headers: HeaderMap, header: &str) -> Result<String, AuthError> {
+fn get_event(headers: &HeaderMap) -> Result<String, AuthError> {
+    get_header(headers, "X-GitHub-Event")
+}
+
+fn get_header(headers: &HeaderMap, header: &str) -> Result<String, AuthError> {
     headers
         .get(header)
         .and_then(|header| header.to_str().ok())
         .map(String::from)
         .ok_or_else(|| AuthError::MissingHeader(header.into()))
+}
+
+fn deserialize_event(_event_type: &str, body: &Bytes) -> Result<Event, AuthError> {
+    let event =
+        Event::Unsupported(serde_json::from_slice(body).map_err(|_| AuthError::UnexpectedPayload)?);
+
+    Ok(event)
 }

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -28,6 +28,7 @@ async fn webhook_accepts_valid_signature() -> Result<(), Error> {
 
     let response = Client::new()
         .post(format!("http://{}/", addr))
+        .header("X-GitHub-Event", "check_run")
         .header(
             "X-Hub-Signature-256",
             "sha256=0ee69dc1afb2d6fd5d09d0163b36c228c3db01dfec1f31c59944938a0bfb4502",


### PR DESCRIPTION
The payload provided in the body of incoming webhooks is now properly deserialized into an event. The event data type comes from the [github-parts] crate, which consumers of octox can depend on to build their workflows.

[github-parts]: https://github.com/devxbots/github-parts