### PR TITLE
Add tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,11 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sha2 = "0.10.2"
 thiserror = "1.0.31"
+tower-http = { version = "0.3.3", features = ["trace"] }
+tracing = "0.1.34"
 
 [dev-dependencies]
 dotenv = "0.15.0"
 mockito = "0.31.0"
 tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use github_parts::event::Event;
 use serde_json::Value;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 use octox::{Error, Octox, Workflow, WorkflowError};
 
@@ -21,6 +23,14 @@ impl Workflow for HelloWorld {
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     dotenv::dotenv().ok();
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::new(
+            std::env::var("RUST_LOG")
+                .unwrap_or_else(|_| "hello_world=debug,tower_http=debug".into()),
+        ))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
 
     let octox = Octox::new().workflow(Arc::new(HelloWorld))?;
     octox.serve().await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use axum::routing::{get, post};
 use axum::{Extension, Router, Server};
+use tower_http::trace::TraceLayer;
 
 use crate::routes::{health, webhook};
 
@@ -76,6 +77,7 @@ impl Octox {
         let app = Router::new()
             .route("/", post(webhook))
             .route("/health", get(health))
+            .layer(TraceLayer::new_for_http())
             .layer(self.workflow_extension()?)
             .layer(self.github_host_extension()?)
             .layer(self.app_id_extension()?)

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -19,6 +19,7 @@ struct Claims {
     exp: i64,
 }
 
+#[tracing::instrument]
 pub async fn health(
     Extension(github_host): Extension<GitHubHost>,
     Extension(app_id): Extension<AppId>,
@@ -37,6 +38,7 @@ pub async fn health(
     (status_code, Json(Health { github }))
 }
 
+#[tracing::instrument]
 async fn check_github(
     github_host: &GitHubHost,
     app_id: &AppId,
@@ -61,6 +63,7 @@ async fn check_github(
     }
 }
 
+#[tracing::instrument]
 fn new_app_token(app_id: &AppId, private_key: &PrivateKey) -> Result<String, Error> {
     let now = Utc::now();
 

--- a/src/routes/webhook.rs
+++ b/src/routes/webhook.rs
@@ -11,6 +11,7 @@ use crate::error::Error;
 use crate::github::WebhookSecret;
 use crate::workflow::Workflow;
 
+#[tracing::instrument(skip(body))]
 pub async fn webhook(
     headers: HeaderMap,
     body: Bytes,
@@ -28,14 +29,17 @@ pub async fn webhook(
     Ok(Json(body))
 }
 
+#[tracing::instrument]
 fn get_signature(headers: &HeaderMap) -> Result<String, AuthError> {
     get_header(headers, "X-Hub-Signature-256")
 }
 
+#[tracing::instrument]
 fn get_event(headers: &HeaderMap) -> Result<String, AuthError> {
     get_header(headers, "X-GitHub-Event")
 }
 
+#[tracing::instrument]
 fn get_header(headers: &HeaderMap, header: &str) -> Result<String, AuthError> {
     headers
         .get(header)
@@ -44,6 +48,7 @@ fn get_header(headers: &HeaderMap, header: &str) -> Result<String, AuthError> {
         .ok_or_else(|| AuthError::MissingHeader(header.into()))
 }
 
+#[tracing::instrument(skip(body))]
 fn deserialize_event(_event_type: &str, body: &Bytes) -> Result<Event, AuthError> {
     let event =
         Event::Unsupported(serde_json::from_slice(body).map_err(|_| AuthError::UnexpectedPayload)?);


### PR DESCRIPTION
Tracing has been added to the framework. By default, every HTTP handler is instrumented so that the inner workings of octox can be observed by its users.