### PR TITLE
Support check run events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ publish = false
 name = "hello-world"
 
 [dependencies]
-github-parts = { git = "https://github.com/devxbots/github-parts", tag = "v0.1.0" }
+github-parts = { git = "https://github.com/devxbots/github-parts", tag = "v0.2.0" }
 
 axum = "0.5.6"
 chrono = "0.4.19"

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("failed to create JWT")]
     Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("{0}")]
+    Payload(#[from] serde_json::Error),
     #[error(transparent)]
     Workflow(#[from] WorkflowError),
     #[error("{0}")]

--- a/src/routes/webhook.rs
+++ b/src/routes/webhook.rs
@@ -49,9 +49,11 @@ fn get_header(headers: &HeaderMap, header: &str) -> Result<String, AuthError> {
 }
 
 #[tracing::instrument(skip(body))]
-fn deserialize_event(_event_type: &str, body: &Bytes) -> Result<Event, AuthError> {
-    let event =
-        Event::Unsupported(serde_json::from_slice(body).map_err(|_| AuthError::UnexpectedPayload)?);
+fn deserialize_event(event_type: &str, body: &Bytes) -> Result<Event, Error> {
+    let event = match event_type {
+        "check_run" => Event::CheckRun(serde_json::from_slice(body)?),
+        _ => Event::Unsupported(serde_json::from_slice(body)?),
+    };
 
     Ok(event)
 }

--- a/tests/fixtures/check_run.created.json
+++ b/tests/fixtures/check_run.created.json
@@ -290,6 +290,7 @@
     "disabled": false,
     "open_issues_count": 2,
     "license": null,
+    "visibility": "public",
     "forks": 1,
     "open_issues": 2,
     "watchers": 0,

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -35,10 +35,10 @@ async fn webhook_accepts_valid_signature() -> Result<(), Error> {
 
     let response = Client::new()
         .post(format!("http://{}/", addr))
-        .header("X-GitHub-Event", "check_run")
+        .header("X-GitHub-Event", "not_a_real_event")
         .header(
             "X-Hub-Signature-256",
-            "sha256=0ee69dc1afb2d6fd5d09d0163b36c228c3db01dfec1f31c59944938a0bfb4502",
+            "sha256=ba9f77aa6bc9740e9be7f68e4e21a64821cc5b59fd286d409d605a0b8affe7ff",
         )
         .body(body)
         .send()


### PR DESCRIPTION
Support for check run events has been added to the github-parts crate that octox uses under the hood, which means octox can support them as well now. Based on the event header, check run events are deserialized from the request payload and passed to the workflow.