### PR TITLE
Run workflows asynchronously

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ sha2 = "0.10.2"
 thiserror = "1.0.31"
 tower-http = { version = "0.3.3", features = ["trace"] }
 tracing = "0.1.34"
+async-trait = "0.1.56"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use github_parts::event::Event;
 use serde_json::Value;
 use tracing_subscriber::layer::SubscriberExt;
@@ -10,8 +11,9 @@ use octox::{Error, Octox, Workflow, WorkflowError};
 #[derive(Debug)]
 struct HelloWorld;
 
+#[async_trait]
 impl Workflow for HelloWorld {
-    fn process(&self, event: Event) -> Result<Value, WorkflowError> {
+    async fn process(&self, event: Event) -> Result<Value, WorkflowError> {
         let body = format!("received {}", event).into();
 
         println!("{}", &body);

--- a/src/routes/webhook.rs
+++ b/src/routes/webhook.rs
@@ -24,7 +24,7 @@ pub async fn webhook(
     let event_type = get_event(&headers)?;
     let event = deserialize_event(&event_type, &body)?;
 
-    let body = workflow.process(event)?;
+    let body = workflow.process(event).await?;
 
     Ok(Json(body))
 }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,12 +1,14 @@
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
 use std::fmt::Debug;
 
+use async_trait::async_trait;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use github_parts::event::Event;
 use thiserror::Error;
 
+#[async_trait]
 pub trait Workflow: Debug + Sync + Send {
-    fn process(&self, event: Event) -> Result<serde_json::Value, WorkflowError>;
+    async fn process(&self, event: Event) -> Result<serde_json::Value, WorkflowError>;
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Error)]

--- a/tests/workflow.rs
+++ b/tests/workflow.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use github_parts::event::Event;
 use serde_json::Value;
 
@@ -6,8 +7,9 @@ use octox::{Workflow, WorkflowError};
 #[derive(Debug)]
 pub struct HelloWorld;
 
+#[async_trait]
 impl Workflow for HelloWorld {
-    fn process(&self, event: Event) -> Result<Value, WorkflowError> {
+    async fn process(&self, event: Event) -> Result<Value, WorkflowError> {
         Ok(format!("received {}", event).into())
     }
 }


### PR DESCRIPTION
The `Workflow` trait has been refactored to expose an asynchronous function. This makes it possible to use async functions in the workflow, for example when interacting with external resources. Since async traits are not stabilized yet, the `async_trait` crate is used to support this feature.