### PR TITLE
Initialize workflow objects using a constructor

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,15 +1,23 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use github_parts::event::Event;
 use serde_json::Value;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-use octox::{Error, Octox, Workflow, WorkflowError};
+use octox::{AppId, Error, GitHubHost, Octox, PrivateKey, Workflow, WorkflowError};
 
 #[derive(Debug)]
 struct HelloWorld;
+
+impl HelloWorld {
+    pub fn constructor(
+        _github_host: GitHubHost,
+        _app_id: AppId,
+        _private_key: PrivateKey,
+    ) -> Box<dyn Workflow> {
+        Box::new(HelloWorld)
+    }
+}
 
 #[async_trait]
 impl Workflow for HelloWorld {
@@ -34,6 +42,6 @@ async fn main() -> Result<(), Error> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let octox = Octox::new().workflow(Arc::new(HelloWorld))?;
+    let octox = Octox::new().workflow(HelloWorld::constructor)?;
     octox.serve().await
 }

--- a/src/routes/webhook.rs
+++ b/src/routes/webhook.rs
@@ -16,7 +16,7 @@ pub async fn webhook(
     headers: HeaderMap,
     body: Bytes,
     Extension(webhook_secret): Extension<WebhookSecret>,
-    Extension(workflow): Extension<Arc<dyn Workflow>>,
+    Extension(workflow): Extension<Arc<Box<dyn Workflow>>>,
 ) -> Result<Json<Value>, Error> {
     let signature = get_signature(&headers)?;
     verify_signature(&body, &signature, &webhook_secret)?;

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,5 +1,4 @@
 use std::net::{SocketAddr, TcpListener};
-use std::sync::Arc;
 
 use mockito::mock;
 use reqwest::Client;
@@ -24,7 +23,7 @@ async fn health_returns_ok() -> Result<(), Error> {
         .app_id(1)?
         .github_host(mockito::server_url())?
         .private_key(include_str!("fixtures/private-key.pem"))?
-        .workflow(Arc::new(HelloWorld))?;
+        .workflow(HelloWorld::constructor)?;
 
     tokio::spawn(async move {
         octox.serve().await.unwrap();
@@ -53,7 +52,7 @@ async fn health_returns_error() -> Result<(), Error> {
     let octox = Octox::new()
         .tcp_listener(listener)?
         .github_host(mockito::server_url())?
-        .workflow(Arc::new(HelloWorld))?;
+        .workflow(HelloWorld::constructor)?;
 
     tokio::spawn(async move {
         octox.serve().await.unwrap();

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -1,6 +1,5 @@
 use std::fs::read;
 use std::net::{SocketAddr, TcpListener};
-use std::sync::Arc;
 
 use reqwest::Client;
 
@@ -21,7 +20,7 @@ async fn webhook_accepts_valid_signature() -> Result<(), Error> {
         .tcp_listener(listener)?
         .github_host(mockito::server_url())?
         .webhook_secret("secret")?
-        .workflow(Arc::new(HelloWorld))?;
+        .workflow(HelloWorld::constructor)?;
 
     tokio::spawn(async move {
         octox.serve().await.unwrap();
@@ -62,7 +61,7 @@ async fn webhook_requires_signature() -> Result<(), Error> {
         .tcp_listener(listener)?
         .github_host(mockito::server_url())?
         .webhook_secret("secret")?
-        .workflow(Arc::new(HelloWorld))?;
+        .workflow(HelloWorld::constructor)?;
 
     tokio::spawn(async move {
         octox.serve().await.unwrap();
@@ -99,7 +98,7 @@ async fn webhook_rejects_invalid_signature() -> Result<(), Error> {
         .tcp_listener(listener)?
         .github_host(mockito::server_url())?
         .webhook_secret("secret")?
-        .workflow(Arc::new(HelloWorld))?;
+        .workflow(HelloWorld::constructor)?;
 
     tokio::spawn(async move {
         octox.serve().await.unwrap();

--- a/tests/workflow.rs
+++ b/tests/workflow.rs
@@ -2,10 +2,20 @@ use async_trait::async_trait;
 use github_parts::event::Event;
 use serde_json::Value;
 
-use octox::{Workflow, WorkflowError};
+use octox::{AppId, GitHubHost, PrivateKey, Workflow, WorkflowError};
 
 #[derive(Debug)]
 pub struct HelloWorld;
+
+impl HelloWorld {
+    pub fn constructor(
+        _github_host: GitHubHost,
+        _app_id: AppId,
+        _private_key: PrivateKey,
+    ) -> Box<dyn Workflow> {
+        Box::new(HelloWorld)
+    }
+}
 
 #[async_trait]
 impl Workflow for HelloWorld {


### PR DESCRIPTION
The interface of octox has been refactored. It no longer takes an initialized workflow object, but instead asks users to provide a function that can create the object. The motivation for the change is that GitHub Apps require some configuration, e.g. the app id and private key, to communicate with GitHub's API. But these values are only available after octox has been initialized itself.

An alternative approach would have been to expose the functions that initialize the app from environment variables. But then users would have to set the same settings twice, once for the workflow object and once for octox.

The current implementation is considered a prototype, which can hopefully be cleaned up a bit as we gather more knowledge about creating workflows for octox.