### PR TITLE
Refactor error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = "1.0.31"
 tower-http = { version = "0.3.3", features = ["trace"] }
 tracing = "0.1.34"
 async-trait = "0.1.56"
+anyhow = "1.0.57"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,30 +7,33 @@ use crate::workflow::WorkflowError;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("failed to call external API")]
-    Api(#[from] reqwest::Error),
-    #[error(transparent)]
-    Auth(#[from] AuthError),
-    #[error("failed to initialize the web framework")]
-    Axum(#[from] hyper::Error),
     #[error("{0}")]
     Configuration(String),
-    #[error("failed to initialize resource")]
-    Io(#[from] std::io::Error),
-    #[error("failed to create JWT")]
-    Jwt(#[from] jsonwebtoken::errors::Error),
-    #[error("{0}")]
+
+    #[error(transparent)]
+    Client(#[from] AuthError),
+
+    #[error(transparent)]
+    ExternalResource(#[from] reqwest::Error),
+
+    #[error("failed to deserialize incoming request payload")]
     Payload(#[from] serde_json::Error),
+
     #[error(transparent)]
     Workflow(#[from] WorkflowError),
-    #[error("{0}")]
-    Unknown(String),
+
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
 }
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        let body = self.to_string();
-
-        (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+        match self {
+            Error::Client(error) => error.into_response(),
+            _ => {
+                let body = self.to_string();
+                (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+            }
+        }
     }
 }

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -51,7 +51,7 @@ async fn check_github(
                 github_parts::error::Error::Configuration(_, message) => {
                     Err(Error::Configuration(message))
                 }
-                _ => Err(Error::Unknown("failed to create GitHub App token".into())),
+                _ => Err(Error::UnexpectedError(error.into())),
             }
         }
     };
@@ -68,6 +68,6 @@ async fn check_github(
         Ok(())
     } else {
         let text = response.text().await?;
-        Err(Error::Unknown(text))
+        Err(Error::UnexpectedError(anyhow::Error::msg(text)))
     }
 }

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -15,7 +15,7 @@ async fn health_returns_ok() -> Result<(), Error> {
 
     let _mock = mock("GET", "/app").with_status(200).create();
 
-    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
 
     let octox = Octox::new()
@@ -46,7 +46,7 @@ async fn health_returns_error() -> Result<(), Error> {
 
     let _mock = mock("GET", "/app").with_status(401).create();
 
-    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
 
     let octox = Octox::new()

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -13,7 +13,7 @@ mod workflow;
 async fn webhook_accepts_valid_signature() -> Result<(), Error> {
     dotenv::dotenv().ok();
 
-    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
 
     let octox = Octox::new()
@@ -54,7 +54,7 @@ async fn webhook_accepts_valid_signature() -> Result<(), Error> {
 async fn webhook_requires_signature() -> Result<(), Error> {
     dotenv::dotenv().ok();
 
-    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
 
     let octox = Octox::new()
@@ -79,6 +79,8 @@ async fn webhook_requires_signature() -> Result<(), Error> {
         .send()
         .await?;
 
+    assert_eq!(400, response.status().as_u16());
+
     assert!(response
         .text()
         .await
@@ -91,7 +93,7 @@ async fn webhook_requires_signature() -> Result<(), Error> {
 async fn webhook_rejects_invalid_signature() -> Result<(), Error> {
     dotenv::dotenv().ok();
 
-    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap())?;
+    let listener = TcpListener::bind("0.0.0.0:0".parse::<SocketAddr>().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
 
     let octox = Octox::new()
@@ -119,6 +121,8 @@ async fn webhook_rejects_invalid_signature() -> Result<(), Error> {
         .body(body)
         .send()
         .await?;
+
+    assert_eq!(401, response.status().as_u16());
 
     assert!(response
         .text()


### PR DESCRIPTION
A first pass has been done to clean up and simplify the errors that the crate exposes. The error handling is still not great, with a significant mental overhead caused by the various different kinds of errors that the crate can return.

As we build out the functionality of the crate and various different workflows, we want to come back to this area and improve it further.