### PR TITLE
Optionally add dependabot to release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,8 +3,6 @@ changelog:
   exclude:
     labels:
       - R-ignore
-    authors:
-      - dependabot
   categories:
     - title: Security
       labels:


### PR DESCRIPTION
Sometimes, we might want to highlight the upgrade of a dependency in the release notes. This isn't currently possible, since every PR by dependabot is ignored even if it has the right label.