### PR TITLE
Create workflows using finite state machines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,13 @@ use tower_http::trace::TraceLayer;
 use crate::routes::{health, webhook};
 
 pub use self::error::Error;
-pub use self::workflow::{Workflow, WorkflowError};
+pub use self::state::State;
+pub use self::workflow::{Step, Transition, Workflow, WorkflowError};
 
 mod auth;
 mod error;
 mod routes;
+mod state;
 mod workflow;
 
 type SharedTokenFactory = Arc<Mutex<TokenFactory>>;

--- a/src/routes/webhook.rs
+++ b/src/routes/webhook.rs
@@ -24,7 +24,7 @@ pub async fn webhook(
     let event_type = get_event(&headers)?;
     let event = deserialize_event(&event_type, &body)?;
 
-    let body = workflow.process(event).await?;
+    let body = workflow.execute(event).await?;
 
     Ok(Json(body))
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,88 @@
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hasher};
+
+type AnyMap = HashMap<TypeId, Box<dyn Any + Send + Sync>, BuildHasherDefault<IdHasher>>;
+
+#[derive(Default)]
+struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("TypeId calls write_u64");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct State {
+    /// Type-based store
+    ///
+    /// The implementation for this type-based map is inspired by the `Extensions` store in the
+    /// [`http`](https://github.com/hyperium/http) crate.
+    store: Box<AnyMap>,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            store: Box::new(HashMap::default()),
+        }
+    }
+
+    pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
+        self.store
+            .insert(TypeId::of::<T>(), Box::new(val))
+            .and_then(|boxed| {
+                (boxed as Box<dyn Any + 'static>)
+                    .downcast()
+                    .ok()
+                    .map(|boxed| *boxed)
+            })
+    }
+
+    pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
+        self.store
+            .get(&TypeId::of::<T>())
+            .and_then(|boxed| (&**boxed as &(dyn Any + 'static)).downcast_ref())
+    }
+
+    pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        self.store
+            .as_mut()
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|boxed| (&mut **boxed as &mut (dyn Any + 'static)).downcast_mut())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::State;
+
+    #[test]
+    fn state_stores_and_returns_value() {
+        let mut state = State::new();
+
+        state.insert(64u32);
+
+        assert_eq!(Some(&64), state.get::<u32>());
+    }
+
+    #[test]
+    fn state_returns_none_when_value_is_missing() {
+        let mut state = State::new();
+
+        state.insert(64u32);
+
+        assert_eq!(None, state.get::<i32>());
+    }
+}

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -44,8 +44,8 @@ async fn webhook_accepts_valid_signature() -> Result<(), Error> {
         .await?;
 
     assert_eq!(
-        "\"received unsupported event\"",
-        response.text().await.unwrap()
+        response.text().await.unwrap(),
+        "\"received unsupported event\""
     );
     Ok(())
 }


### PR DESCRIPTION
A first implementation of a finite state machine framework for creating workflows has been added aand replaces the previous `Workflow` trait. Building workflows as state machine makes the individual steps in the workflow more explicit and easier to test, thus decreasing the complexity of the workflow.